### PR TITLE
Fixing tooltips going out of screen on achievement list

### DIFF
--- a/Retro Achievement Tracker/Resources/achievement-list-window.html
+++ b/Retro Achievement Tracker/Resources/achievement-list-window.html
@@ -47,7 +47,10 @@
             $("#achievement-" + achievement.id).tooltip({
                 items: 'div',
                 content: tooltipString,
-                track: true
+                track: true,
+                position: {
+                    within: '#container'
+                }
             });
         }
 


### PR DESCRIPTION
Solves #29 by forcing the tooltip to be inside the only container having a proper size (#container)

Here is the render after fixing it :

![image](https://github.com/user-attachments/assets/4d4f87d8-1b11-4b6a-b754-e7afd407d72e)

Thank you !